### PR TITLE
Amend link in readme for local host

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To run the site locally for development, run
 make run
 ```
 
-This will install, build and run the site with Jekyll and run the dev server in watch mode so that it picks up any changes in the source. You can view the site on [http://localhost:4000](http://localhost:4000).
+This will install, build and run the site with Jekyll and run the dev server in watch mode so that it picks up any changes in the source. You can view the site on [http://localhost:4000/help/](http://localhost:4000/help/).
 
 To test the built site and make sure there are no dead links / images, run:
 


### PR DESCRIPTION
- Changed link endpoint from http://localhost:4000/ ---> http://localhost:4000/help/ as it served a 404 when clicked from the readme



