### PR TITLE
Escaped astersisk in help docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,6 @@ jobs:
         ruby-version: 3.0
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Build
-      run: bundle exec jekyll build --trace
+      run: bundle exec jekyll build 
     - name: Run tests
       run: bundle exec htmlproofer --disable-external ./_site --url-swap '^/help/:/'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,6 @@ jobs:
         ruby-version: 3.0
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Build
-      run: bundle exec jekyll build
+      run: bundle exec jekyll build --trace
     - name: Run tests
       run: bundle exec htmlproofer --disable-external ./_site --url-swap '^/help/:/'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2
+        ruby-version: 3.0
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Build
       run: bundle exec jekyll build --trace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0
+        ruby-version: 3.2
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Build
       run: bundle exec jekyll build --trace

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.2.1"
 gem "webrick", "~> 1.7"
-gem "nokogiri", "~> 1.13"
+gem "nokogiri", "~> 1.14"
 gem 'html-proofer'

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.2.1"
 gem "webrick", "~> 1.7"
-gem "nokogiri", "~> 1.13.9"
-gem 'html-proofer'
+gem "nokogiri", "~> 1.14"
+gem "html-proofer", "3.19.3"

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.2.1"
 gem "webrick", "~> 1.7"
-gem "nokogiri", "~> 1.14"
+gem "nokogiri", "~> 1.13.9"
 gem 'html-proofer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,19 +52,19 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    nokogiri (1.13.1-aarch64-linux)
+    nokogiri (1.14.0-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.13.1-arm64-darwin)
+    nokogiri (1.14.0-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.1-x86_64-darwin)
+    nokogiri (1.14.0-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.1-x86_64-linux)
+    nokogiri (1.14.0-x86_64-linux)
       racc (~> 1.4)
     parallel (1.21.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
-    racc (1.6.0)
+    racc (1.6.2)
     rainbow (3.1.1)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
@@ -90,7 +90,7 @@ PLATFORMS
 DEPENDENCIES
   html-proofer
   jekyll (~> 4.2.1)
-  nokogiri (~> 1.13)
+  nokogiri (~> 1.14)
   webrick (~> 1.7)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
-    ethon (0.15.0)
+    ethon (0.16.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     ffi (1.15.5)
@@ -22,9 +22,9 @@ GEM
       typhoeus (~> 1.3)
       yell (~> 2.0)
     http_parser.rb (0.8.0)
-    i18n (1.9.1)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    jekyll (4.2.1)
+    jekyll (4.2.2)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -39,38 +39,32 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 2.0)
-    jekyll-sass-converter (2.1.0)
+    jekyll-sass-converter (2.2.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.3.1)
+    kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    liquid (4.0.3)
-    listen (3.7.1)
+    liquid (4.0.4)
+    listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    nokogiri (1.13.10-aarch64-linux)
+    nokogiri (1.14.0-x86_64-linux)
       racc (~> 1.4)
-    nokogiri (1.13.10-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-linux)
-      racc (~> 1.4)
-    parallel (1.21.0)
+    parallel (1.22.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (4.0.6)
+    public_suffix (5.0.1)
     racc (1.6.2)
     rainbow (3.1.1)
-    rb-fsevent (0.11.0)
+    rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
-    rouge (3.28.0)
+    rouge (3.30.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -83,15 +77,13 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
-  aarch64-linux
-  universal-darwin-20
   x86_64-linux
 
 DEPENDENCIES
-  html-proofer
+  html-proofer (= 3.19.3)
   jekyll (~> 4.2.1)
-  nokogiri (~> 1.13.9)
+  nokogiri (~> 1.14)
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.3.6
+   2.2.33

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,13 +52,13 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    nokogiri (1.14.0-aarch64-linux)
+    nokogiri (1.13.10-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.14.0-arm64-darwin)
+    nokogiri (1.13.10-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.0-x86_64-darwin)
+    nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.0-x86_64-linux)
+    nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
     parallel (1.21.0)
     pathutil (0.16.2)
@@ -90,7 +90,7 @@ PLATFORMS
 DEPENDENCIES
   html-proofer
   jekyll (~> 4.2.1)
-  nokogiri (~> 1.14)
+  nokogiri (~> 1.13.9)
   webrick (~> 1.7)
 
 BUNDLED WITH

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 
 .PHONY: build
 build: install
-	$(DOCKER_EXEC_CMD) bundle exec jekyll build
+	$(DOCKER_EXEC_CMD) bundle exec jekyll build --trace
 
 .PHONY: run
 run: install

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 
 .PHONY: build
 build: install
-	$(DOCKER_EXEC_CMD) bundle exec jekyll build --trace
+	$(DOCKER_EXEC_CMD) bundle exec jekyll build 
 
 .PHONY: run
 run: install

--- a/site/bichard-functionality/index.md
+++ b/site/bichard-functionality/index.md
@@ -95,7 +95,7 @@ When you have selected your filter values, click on the refresh button at the to
 
 ## Searching
 
-The search facility will allow users to lookup records via a defendant name or by court. The search looks for an exact match to the search term entered. A common search facility (known as a wildcard) is used to allow users greater flexibility in searching. A wildcard is a character that may be used in a search to represent one or more characters – this is an asterisk '*'. Wildcards can be used at the start, end or in the middle of words, e.g. S*H would return both Smith and South.
+The search facility will allow users to lookup records via a defendant name or by court. The search looks for an exact match to the search term entered. A common search facility (known as a wildcard) is used to allow users greater flexibility in searching. A wildcard is a character that may be used in a search to represent one or more characters – this is an asterisk '\*'. Wildcards can be used at the start, end or in the middle of words, e.g. S*H would return both Smith and South.
 
 It should also be noted that searches are NOT case sensitive.
 


### PR DESCRIPTION
The section on how to search in the `bichard-functionality` section described how to use the `*` wildcard but wasn't being rendered. The fix was just to escape the character